### PR TITLE
Fix for issue #3 - Added slack group chat link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ Get a barebones Extension to VSCode up -> Add Voice to Text Feature to Extension
 
 
 Add research notes as a wiki page. 
+
+
+Here is the [Slack group chat] (https://join.slack.com/t/codetalkerworkspace/shared_invite/enQtNDcyMjQ4MjYzNzMwLTYzMjM4MDUwMzAzYTc1MjBhNDNjZWM5MGU5Y2FkODUzMWZjM2M4NjJlZGZkYjIwNTNlYzM1NGQxOGYzNDUyOTY) where we discuss any issues and suggestions regarding this project.


### PR DESCRIPTION
I have added the link to invite contributors to the Slack group chat for CodeTalkers.

I have also added the link at the bottom of the issue.

Thank You!